### PR TITLE
add Keyboard shortcut to temporarily disable AB download manager interception (#37)

### DIFF
--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -136,5 +136,11 @@
   },
   "config_capture_file_size_limit_kb_description": {
     "message": "Only capture files with size greater than or equal to this value in kilobytes. Set 0 to capture all sizes."
+  },
+  "config_short_cut": {
+    "message": "Shortcut"
+  },
+  "config_short_cut_description": {
+    "message": "When auto-capture of download links is enabled, holding down the shortcut key and clicking on the download link uses the internal browser download method."
   }
 }

--- a/src/configs/Config.ts
+++ b/src/configs/Config.ts
@@ -58,6 +58,7 @@ export const defaultConfig: Config = {
     silentStartDownload: false,
     // 0 means no minimum (capture all sizes)
     captureFileSizeMinimumKb: 0,
+    shortCut:"Control",
 }
 
 export const configKeys: ReadonlyArray<keyof Config> = Object.keys(defaultConfig) as any
@@ -87,6 +88,7 @@ export interface Config {
     blacklistedUrls: string[]
     // minimum file size to capture in kilobytes. 0 = no minimum (capture all sizes)
     captureFileSizeMinimumKb: number
+    shortCut: string,
 }
 
 export const MIN_ALLOWED_PORT = 1024

--- a/src/contentscripts/ContentScript.ts
+++ b/src/contentscripts/ContentScript.ts
@@ -9,6 +9,7 @@ import {onMessage} from "webext-bridge/content-script"
 import browser from "webextension-polyfill";
 import {createAlertStringForMyExtension} from "~/utils/AlertMessageCreator";
 import {addDownloads} from "~/contentscripts/AddDownloads";
+import {sendMessage} from "webext-bridge/options";
 
 const showPopupDelayed = debounce(500)
 
@@ -56,6 +57,16 @@ run(async () => {
     document.addEventListener("selectionchange", () => {
         lastSelectionConsumed = true
     })
+
+    let keyName = ""
+    document.addEventListener("keydown", (e) => {
+        keyName = e.key
+    })
+
+    document.addEventListener("keyup", (e) => {
+        keyName = ""
+    })
+
     document.addEventListener("mouseup", () => {
         showPopupDelayed(() => {
             const mousePositionInPage = mousePosition.getMousePositionInPage();
@@ -76,7 +87,15 @@ run(async () => {
             lastSelectionConsumed = false
             selectionPopup.showAddDownloadPopupUi(mousePositionInPage)
         })
+        sendMessage('get_event',keyName).finally(()=>{
+            keyName = ""
+        })
     })
+
+    window.addEventListener('blur', function() {
+        keyName = ""
+    })
+
     onMessage("show_log", (msg) => {
         console.log(...msg.data)
     })

--- a/src/optionsui/OptionUi.tsx
+++ b/src/optionsui/OptionUi.tsx
@@ -81,6 +81,9 @@ class ToolsViewModel extends EventAwareViewModel<ToolsViewModelEvent> implements
     @observable
     captureFileSizeMinimumKb!: number
 
+    @observable
+    shortCut!: string
+
     setAutoCaptureLinks(value: boolean) {
         Configs.setConfigItem("autoCaptureLinks", value)
     }
@@ -95,6 +98,10 @@ class ToolsViewModel extends EventAwareViewModel<ToolsViewModelEvent> implements
 
     setCaptureFileSizeMinimumKb(value: number) {
         Configs.setConfigItem("captureFileSizeMinimumKb", value)
+    }
+
+    setShortCut(value: string){
+        Configs.setConfigItem("shortCut", value)
     }
 
     setPopupEnabled(value: boolean) {
@@ -222,6 +229,8 @@ const SettingsSection: React.FC<{ vm: ToolsViewModel }> = observer((props) => {
                 setBlacklistedUrls={urls => vm.setBlacklistedUrls(urls)}
                 captureFileSizeMinimumKb={vm.captureFileSizeMinimumKb}
                 setCaptureFileSizeMinimumKb={(v) => vm.setCaptureFileSizeMinimumKb(v)}
+                shortCut={vm.shortCut}
+                setShortCut={(v) => vm.setShortCut(v)}
             />
             <Divider/>
             <ShowPopupSection value={vm.popupEnabled} toggle={(v) => vm.setPopupEnabled(v)}/>
@@ -362,6 +371,8 @@ function AutoCaptureSection(
         defaultBlacklistedUrls: string[],
         captureFileSizeMinimumKb: number,
         setCaptureFileSizeMinimumKb: (n: number) => void,
+        shortCut:string,
+        setShortCut:(s: string) => void,
     }
 ) {
     const [fileTypesString, setFileTypesString] = useState<string>("")
@@ -473,6 +484,20 @@ function AutoCaptureSection(
                         <span className="text-xs text-muted">KB</span>
                     </div>
                 </div>
+                <div className="mt-2"/>
+                <div className="flex flex-col space-y-2">
+                    <label>{browser.i18n.getMessage("config_short_cut")}</label>
+                    <div className="flex items-center space-x-2">
+                        <select
+                            value={props.shortCut}
+                            onChange={(e) => props.setShortCut(e.target.value)}
+                            className="select select-sm flex-1"
+                        >
+                            <option value={"Control"}>Control</option>
+                        </select>
+                    </div>
+                </div>
+                <div>{browser.i18n.getMessage("config_short_cut_description")}</div>
             </div>
         }
     />

--- a/src/shim.d.ts
+++ b/src/shim.d.ts
@@ -12,6 +12,7 @@ declare module "webext-bridge" {
         show_log:string[];
         check_selected_text_for_links:null;
         test_port:ProtocolWithReturn<number,boolean>;
-        get_headers:ProtocolWithReturn<string[],(DownloadRequestHeaders | null)[]>
+        get_headers:ProtocolWithReturn<string[],(DownloadRequestHeaders | null)[]>;
+        get_event:string;
     }
 }


### PR DESCRIPTION
When auto-capture of download links is enabled, holding down the shortcut key(ctrl)  and clicking on the download link uses the internal browser download method.
Currently, only one key combination is set by default, [ctrl], and [shift] will pop up a new window, so it's not added.
add Keyboard shortcut to temporarily disable AB download manager interception (#37)