### PR TITLE
fix typo (don"t -> don't)

### DIFF
--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -90,7 +90,7 @@
     "message": "Send Cookies"
   },
   "config_send_cookies_descrption": {
-    "message": "Note: DON”T Check this if you are in a non trustable environment"
+    "message": "Note: DON'T Check this if you are in a non trustable environment"
   },
   "browser_action_more_settings": {
     "message": "More Settings"


### PR DESCRIPTION
fixed a small typo where a quotation mark was used rather than an apostrophe 