### PR TITLE
feat: add invert mode for file extension filter (allowlist/denylist toggle)

### DIFF
--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -1,146 +1,149 @@
 {
-  "selection_popup_download_selected": {
-    "message": "Download selected"
-  },
-  "popup_alert_no_link_detected": {
-    "message": "No links detected"
-  },
-  "popup_alert_nothing_selected": {
-    "message": "Please first make a selection"
-  },
-  "context_menu_download_with_abdm": {
-    "message": "Download with AB DM"
-  },
-  "context_menu_download_selected_links_with_abdm": {
-    "message": "Download selected links with AB DM"
-  },
-  "browser_action_popup_title": {
-    "message": "AB DM Quick Settings"
-  },
-  "option_ui_title": {
-    "message": "AB Download Manager Extension"
-  },
-  "connection_connected": {
-    "message": "Connected"
-  },
-  "connection_not_connected": {
-    "message": "Not Connected"
-  },
-  "connection_checking": {
-    "message": "Checking"
-  },
-  "config_auto_capture_links": {
-    "message": "Auto Capture Links"
-  },
-  "config_auto_capture_links_description": {
-    "message": "When you click on a link in your browser it will automatically be captured for download by the app"
-  },
-  "reset_to_default": {
-    "message": "Reset to default"
-  },
-  "config_auto_capture_links_file_extensions_description": {
-    "message": "Enter each file extension that you want to be captured then press enter"
-  },
-  "config_blacklisted_urls_description": {
-    "message": "Enter URLs you don't want to be captured (one per line, wildcards (*) supported)"
-  },
-  "config_silent_add_download": {
-    "message": "Add downloads silently"
-  },
-  "config_silent_add_download_description": {
-    "message": "Automatically add captured downloads to the download list without showing the \"Add Download\" window"
-  },
-  "config_silent_start_download": {
-    "message": "Start download silently"
-  },
-  "config_silent_start_download_description": {
-    "message": "Automatically start captured downloads without showing the \"Add Download\" window"
-  },
-  "config_show_popups": {
-    "message": "Show popups"
-  },
-  "config_show_popups_description": {
-    "message": "Show popup on selections which have links"
-  },
-  "config_port": {
-    "message": "Port"
-  },
-  "config_port_description": {
-    "message": "Make sure this port and the value in the app are the same otherwise this extension will not work properly"
-  },
-  "config_port_connection_success": {
-    "message": "Success\nPort ($port$) Is connected",
-    "placeholders": {
-      "port": {
-        "content": "$1",
-        "example": "15151"
-      }
+    "selection_popup_download_selected": {
+        "message": "Download selected"
+    },
+    "popup_alert_no_link_detected": {
+        "message": "No links detected"
+    },
+    "popup_alert_nothing_selected": {
+        "message": "Please first make a selection"
+    },
+    "context_menu_download_with_abdm": {
+        "message": "Download with AB DM"
+    },
+    "context_menu_download_selected_links_with_abdm": {
+        "message": "Download selected links with AB DM"
+    },
+    "browser_action_popup_title": {
+        "message": "AB DM Quick Settings"
+    },
+    "option_ui_title": {
+        "message": "AB Download Manager Extension"
+    },
+    "connection_connected": {
+        "message": "Connected"
+    },
+    "connection_not_connected": {
+        "message": "Not Connected"
+    },
+    "connection_checking": {
+        "message": "Checking"
+    },
+    "config_auto_capture_links": {
+        "message": "Auto Capture Links"
+    },
+    "config_auto_capture_links_description": {
+        "message": "When you click on a link in your browser it will automatically be captured for download by the app"
+    },
+    "reset_to_default": {
+        "message": "Reset to default"
+    },
+    "config_auto_capture_links_file_extensions_description": {
+        "message": "Enter each file extension that you want to be captured then press enter"
+    },
+    "config_blacklisted_urls_description": {
+        "message": "Enter URLs you don't want to be captured (one per line, wildcards (*) supported)"
+    },
+    "config_silent_add_download": {
+        "message": "Add downloads silently"
+    },
+    "config_silent_add_download_description": {
+        "message": "Automatically add captured downloads to the download list without showing the \"Add Download\" window"
+    },
+    "config_silent_start_download": {
+        "message": "Start download silently"
+    },
+    "config_silent_start_download_description": {
+        "message": "Automatically start captured downloads without showing the \"Add Download\" window"
+    },
+    "config_show_popups": {
+        "message": "Show popups"
+    },
+    "config_show_popups_description": {
+        "message": "Show popup on selections which have links"
+    },
+    "config_port": {
+        "message": "Port"
+    },
+    "config_port_description": {
+        "message": "Make sure this port and the value in the app are the same otherwise this extension will not work properly"
+    },
+    "config_port_connection_success": {
+        "message": "Success\nPort ($port$) Is connected",
+        "placeholders": {
+            "port": {
+                "content": "$1",
+                "example": "15151"
+            }
+        }
+    },
+    "config_port_connection_fail": {
+        "message": "Failure\nPort ($port$) not connected",
+        "placeholders": {
+            "port": {
+                "content": "$1",
+                "example": "15151"
+            }
+        }
+    },
+    "config_send_cookies": {
+        "message": "Send Cookies"
+    },
+    "config_send_cookies_descrption": {
+        "message": "Note: DON'T check this if you are in a non-trusted environment"
+    },
+    "browser_action_more_settings": {
+        "message": "More settings"
+    },
+    "connection_error_api_error": {
+        "message": "There is a problem with the app api, make sure to update both the app and extension to the latest version"
+    },
+    "connection_error_network_error": {
+        "message": "Can't connect to the application, please make sure the app is installed and running. Also ensure the Browser Integration feature is turned On in the application settings"
+    },
+    "settings": {
+        "message": "Settings"
+    },
+    "test": {
+        "message": "Test"
+    },
+    "note_about_app_must_be_installed_first": {
+        "message": "In order for this extension to work properly, make sure AB Download Manager is installed, if it doesn't..."
+    },
+    "download_abdm_app": {
+        "message": "Download The App"
+    },
+    "project_website": {
+        "message": "Project Website"
+    },
+    "support_by_rating": {
+        "message": "If you like this work, don't forget to support me by your comments/ratings and also share it with your friends"
+    },
+    "project_source_code": {
+        "message": "Project Source Code"
+    },
+    "abdm_notification_title": {
+        "message": "AB Download Manager"
+    },
+    "abdm_notification_download_captured_silently": {
+        "message": "Download captured silently"
+    },
+    "download_media_title": {
+        "message": "Download With ABDM"
+    },
+    "config_capture_file_size_limit_kb": {
+        "message": "Capture file size minimum (KB)"
+    },
+    "config_capture_file_size_limit_kb_description": {
+        "message": "Only capture files with size greater than or equal to this value in kilobytes. Set 0 to capture all sizes."
+    },
+    "config_bypass_shortcut": {
+        "message": "Bypass Shortcut"
+    },
+    "config_bypass_shortcut_description": {
+        "message": "When auto-capture of download links is enabled, holding down the shortcut key and clicking on the download link uses the internal browser download method."
+    },
+    "config_auto_capture_links_file_extensions_denylist_description": {
+        "message": "Enter each file extension that you want NOT to be captured then press enter"
     }
-  },
-  "config_port_connection_fail": {
-    "message": "Failure\nPort ($port$) not connected",
-    "placeholders": {
-      "port": {
-        "content": "$1",
-        "example": "15151"
-      }
-    }
-  },
-  "config_send_cookies": {
-    "message": "Send Cookies"
-  },
-  "config_send_cookies_descrption": {
-    "message": "Note: DON'T check this if you are in a non-trusted environment"
-  },
-  "browser_action_more_settings": {
-    "message": "More settings"
-  },
-  "connection_error_api_error": {
-    "message": "There is a problem with the app api, make sure to update both the app and extension to the latest version"
-  },
-  "connection_error_network_error": {
-    "message": "Can't connect to the application, please make sure the app is installed and running. Also ensure the Browser Integration feature is turned On in the application settings"
-  },
-  "settings": {
-    "message": "Settings"
-  },
-  "test": {
-    "message": "Test"
-  },
-  "note_about_app_must_be_installed_first": {
-    "message": "In order for this extension to work properly, make sure AB Download Manager is installed, if it doesn't..."
-  },
-  "download_abdm_app": {
-    "message": "Download The App"
-  },
-  "project_website": {
-    "message": "Project Website"
-  },
-  "support_by_rating": {
-    "message": "If you like this work, don't forget to support me by your comments/ratings and also share it with your friends"
-  },
-  "project_source_code": {
-    "message": "Project Source Code"
-  },
-  "abdm_notification_title": {
-    "message": "AB Download Manager"
-  },
-  "abdm_notification_download_captured_silently": {
-    "message": "Download captured silently"
-  },
-  "download_media_title": {
-    "message": "Download With ABDM"
-  },
-  "config_capture_file_size_limit_kb": {
-    "message": "Capture file size minimum (KB)"
-  },
-  "config_capture_file_size_limit_kb_description": {
-    "message": "Only capture files with size greater than or equal to this value in kilobytes. Set 0 to capture all sizes."
-  },
-  "config_bypass_shortcut": {
-    "message": "Bypass Shortcut"
-  },
-  "config_bypass_shortcut_description": {
-    "message": "When auto-capture of download links is enabled, holding down the shortcut key and clicking on the download link uses the internal browser download method."
-  }
 }

--- a/src/configs/Config.ts
+++ b/src/configs/Config.ts
@@ -59,6 +59,7 @@ export const defaultConfig: Config = {
     // 0 means no minimum (capture all sizes)
     captureFileSizeMinimumKb: 0,
     bypassShortcut: "Delete",
+    fileExtensionFilterMode: "allowlist",
 }
 
 export const configKeys: ReadonlyArray<keyof Config> = Object.keys(defaultConfig) as any
@@ -89,6 +90,7 @@ export interface Config {
     // minimum file size to capture in kilobytes. 0 = no minimum (capture all sizes)
     captureFileSizeMinimumKb: number
     bypassShortcut: string,
+    fileExtensionFilterMode: "allowlist" | "denylist",
 }
 
 export const MIN_ALLOWED_PORT = 1024

--- a/src/linkgrabber/DownloadLinkInterceptor.ts
+++ b/src/linkgrabber/DownloadLinkInterceptor.ts
@@ -121,11 +121,15 @@ export abstract class DownloadLinkInterceptor {
     }
 
     protected isInRegisteredFileFormats(fileExtension: string) {
+        const config = Configs.getLatestConfig()
         const extension = fileExtension.toLowerCase()
-        if (!Configs.getLatestConfig().registeredFileTypes.includes(extension)) {
-            return false
+        const listed = config.registeredFileTypes.includes(extension)
+        if (config.fileExtensionFilterMode === "denylist") {
+            // Invert mode: capture everything EXCEPT the listed extensions
+            return !listed
         }
-        return true
+        // Default allowlist mode: capture only listed extensions
+        return listed
     }
 
     private doWeAcceptThisFileSize(contentLength: number | null): boolean {

--- a/src/optionsui/OptionUi.tsx
+++ b/src/optionsui/OptionUi.tsx
@@ -70,6 +70,9 @@ class ToolsViewModel extends EventAwareViewModel<ToolsViewModelEvent> implements
     registeredFileTypes!: string[]
 
     @observable
+    fileExtensionFilterMode!: "allowlist" | "denylist"
+
+    @observable
     blacklistedUrls!: string[]
 
     @observable
@@ -90,6 +93,10 @@ class ToolsViewModel extends EventAwareViewModel<ToolsViewModelEvent> implements
 
     setRegisteredFileTypes(types: string[]) {
         Configs.setConfigItem("registeredFileTypes", [...new Set(types)])
+    }
+
+    setFileExtensionFilterMode(mode: "allowlist" | "denylist") {
+        Configs.setConfigItem("fileExtensionFilterMode", mode)
     }
 
     setBlacklistedUrls(blacklistedUrls: string[]) {
@@ -227,6 +234,8 @@ const SettingsSection: React.FC<{ vm: ToolsViewModel }> = observer((props) => {
                 defaultBlacklistedUrls={defaultConfig.blacklistedUrls}
                 setFileTypes={types => vm.setRegisteredFileTypes(types)}
                 setBlacklistedUrls={urls => vm.setBlacklistedUrls(urls)}
+                fileExtensionFilterMode={vm.fileExtensionFilterMode}
+                setFileExtensionFilterMode={(m) => vm.setFileExtensionFilterMode(m)}
                 captureFileSizeMinimumKb={vm.captureFileSizeMinimumKb}
                 setCaptureFileSizeMinimumKb={(v) => vm.setCaptureFileSizeMinimumKb(v)}
                 bypassShortcut={vm.bypassShortcut}
@@ -373,6 +382,8 @@ function AutoCaptureSection(
         setCaptureFileSizeMinimumKb: (n: number) => void,
         bypassShortcut: string,
         setBypassShortcut: (s: string) => void,
+        fileExtensionFilterMode: "allowlist" | "denylist",
+        setFileExtensionFilterMode: (m: "allowlist" | "denylist") => void,
     }
 ) {
     const [fileTypesString, setFileTypesString] = useState<string>("")
@@ -417,6 +428,21 @@ function AutoCaptureSection(
             <div className="flex flex-col">
                 <div>{browser.i18n.getMessage("config_auto_capture_links_description")}</div>
                 <div className="mt-2"/>
+                <div className="flex flex-row items-center space-x-2 mb-2">
+                    <button
+                        className={classNames("btn btn-xs", props.fileExtensionFilterMode === "denylist" ? "btn-warning" : "btn-outline")}
+                        title={props.fileExtensionFilterMode === "allowlist"
+                            ? "Switch to denylist: capture all extensions EXCEPT those listed"
+                            : "Switch to allowlist: capture ONLY listed extensions"}
+                        onClick={() =>
+                            props.setFileExtensionFilterMode(
+                                props.fileExtensionFilterMode === "allowlist" ? "denylist" : "allowlist"
+                            )
+                        }
+                    >
+                        {props.fileExtensionFilterMode === "allowlist" ? "⇄ Invert" : "⇄ Inverted (active)"}
+                    </button>
+                </div>
                 <AutoGrowingTextarea
                     className="textarea"
                     value={fileTypesString}
@@ -434,7 +460,10 @@ function AutoCaptureSection(
                     )
                 }
                 <div className="mt-2"/>
-                <div>{browser.i18n.getMessage("config_auto_capture_links_file_extensions_description")}</div>
+                <div>{props.fileExtensionFilterMode === "allowlist"
+                    ? browser.i18n.getMessage("config_auto_capture_links_file_extensions_description")
+                    : browser.i18n.getMessage("config_auto_capture_links_file_extensions_denylist_description")
+                }</div>
                 <div className="mt-3"/>
                 <div>Ignored Url patterns</div>
                 <div className="mt-2"/>


### PR DESCRIPTION
Add the ability to invert the file extension filter in the extension settings. Previously, only an allowlist was supported (capture only listed extensions). Users can now toggle to denylist mode, where all downloads are captured EXCEPT the listed extensions.

- Config: add `fileExtensionFilterMode` ("allowlist" | "denylist"), defaults to "allowlist" for backward compatibility
- DownloadLinkInterceptor: respect filter mode in `isInRegisteredFileFormats()` — inverts match logic when denylist is active
- OptionUi: add "⇄ Invert" toggle button above the file extension textarea; button highlights when denylist mode is active; description text updates dynamically to reflect current mode
- i18n: add `config_auto_capture_links_file_extensions_denylist_description` message to en/messages.json