### PR TITLE
fix: user input extension case

### DIFF
--- a/src/optionsui/OptionUi.tsx
+++ b/src/optionsui/OptionUi.tsx
@@ -421,7 +421,7 @@ function AutoCaptureSection(
                     className="textarea"
                     value={fileTypesString}
                     onChange={(event) => {
-                        setFileTypesString(event.target.value)
+                        setFileTypesString(event.target.value.toLowerCase())
                     }}
                 />
                 {


### PR DESCRIPTION
always keep user added extensions lowercase because extensions from files are converted to lowercase as well