### PR TITLE
Group Google Drive archive parts into one download

### DIFF
--- a/src/interfaces/DownloadRequestItem.ts
+++ b/src/interfaces/DownloadRequestItem.ts
@@ -1,10 +1,18 @@
 
+export interface DownloadRequestBundleSource {
+    link: string
+    headers: DownloadRequestHeaders | null
+    suggestedName: string
+    contentLength: number
+}
+
 export interface DownloadRequestItem {
     link: string
     downloadPage: string | null
     headers: DownloadRequestHeaders | null
     description: string | null,
     suggestedName: string | null,
-    type: "hls" | "http"
+    type: "hls" | "http" | "http-bundle"
+    sources?: DownloadRequestBundleSource[]
 }
 export type DownloadRequestHeaders = Record<string, string>

--- a/src/linkgrabber/DownloadLinkInterceptor.ts
+++ b/src/linkgrabber/DownloadLinkInterceptor.ts
@@ -17,6 +17,7 @@ import {getContentLength, getContentType} from "~/utils/HeaderUtils";
 import {getFileExtension, getFileFromHeaders, getFileFromUrl} from "~/utils/URLUtils";
 import _ from "lodash";
 import * as BackgroundSharedState from "~/background/BackgroundSharedState";
+import {shouldDeferGoogleDriveDownloadToBrowser} from "~/linkgrabber/GoogleDriveDownloadInterception";
 
 type TabInfo = {
     title?: string,
@@ -173,6 +174,9 @@ export abstract class DownloadLinkInterceptor {
             return false
         }
         const downloadPage = this.getDownloadPage(details)
+        if (shouldDeferGoogleDriveDownloadToBrowser(downloadPage, details.url)) {
+            return false
+        }
         if (downloadPage && this.isInConfigBlacklist(downloadPage)) {
             return false
         }

--- a/src/linkgrabber/DownloadLinkInterceptor.ts
+++ b/src/linkgrabber/DownloadLinkInterceptor.ts
@@ -18,6 +18,14 @@ import {getFileExtension, getFileFromHeaders, getFileFromUrl} from "~/utils/URLU
 import _ from "lodash";
 import * as BackgroundSharedState from "~/background/BackgroundSharedState";
 import {shouldDeferGoogleDriveDownloadToBrowser} from "~/linkgrabber/GoogleDriveDownloadInterception";
+import {AsyncBatcher} from "~/utils/AsyncBatcher";
+import {
+    createGoogleDriveDownloadRequest,
+    getGoogleDriveBatchKey,
+    GOOGLE_DRIVE_BATCH_DEBOUNCE_MS,
+    GOOGLE_DRIVE_BATCH_MAX_WAIT_MS,
+    GoogleDriveCapturedDownload,
+} from "~/linkgrabber/GoogleDriveDownloadBatching";
 
 type TabInfo = {
     title?: string,
@@ -35,6 +43,13 @@ export abstract class DownloadLinkInterceptor {
     protected readonly pendingRequests: Record<string, InterceptedBrowserRequestWithResponse> = {}
     private onMediaDetectedListener: OnMediaInterceptedFromRequestListener | null = null
     private tabCache: Record<number, TabInfo> = {}
+    private readonly googleDriveDownloadBatcher = new AsyncBatcher<GoogleDriveCapturedDownload, boolean>(
+        async captures => await this.requestAddDownloads(createGoogleDriveDownloadRequest(captures)),
+        {
+            debounceMs: GOOGLE_DRIVE_BATCH_DEBOUNCE_MS,
+            maxWaitMs: GOOGLE_DRIVE_BATCH_MAX_WAIT_MS,
+        },
+    )
 
     protected setPendingRequest(id: string, requestHeaders: WebRequest.OnSendHeadersDetailsType) {
         let request = this.pendingRequests[id]
@@ -218,12 +233,24 @@ export abstract class DownloadLinkInterceptor {
     }
 
 
-    protected async requestAddDownload(item: DownloadRequestItem) {
-        const result = await addDownload([item])
+    protected async requestAddDownloads(items: DownloadRequestItem[]) {
+        const result = await addDownload(items)
         if (getLatestConfig().allowPassDownloadIfAppNotRespond) {
             return result
         }
         return true
+    }
+
+    protected async requestAddDownload(item: DownloadRequestItem) {
+        return await this.requestAddDownloads([item])
+    }
+
+    private async requestGoogleDriveCapturedDownload(
+        capture: GoogleDriveCapturedDownload,
+        tabId: number | null | undefined,
+    ) {
+        const key = getGoogleDriveBatchKey(tabId, capture.item.downloadPage)
+        return await this.googleDriveDownloadBatcher.enqueue(key, capture)
     }
 
     protected createDirectDownloadItemFromWebRequest(
@@ -482,6 +509,10 @@ export abstract class DownloadLinkInterceptor {
             if (_.isEmpty(requestHeaders)) {
                 requestHeaders = await getHeadersForUrl(downloadUrl) || {}
             }
+            let responseFileName: string | null = null
+            let responseContentLength = details.totalBytes >= 0
+                ? details.totalBytes
+                : details.fileSize >= 0 ? details.fileSize : null
             if (interceptedRequest?.finalResponse) {
                 const response = interceptedRequest.finalResponse
                 if (this.isInConfigBlacklist(response.originUrl || response.url)) {
@@ -491,18 +522,34 @@ export abstract class DownloadLinkInterceptor {
                 if (!this.isDirectDownloadContent(response, responseHeaders)) {
                     return
                 }
+                responseFileName = getFileFromHeaders(responseHeaders)
+                responseContentLength = getContentLength(responseHeaders) ?? responseContentLength
             }
 
             await this.cancelDownload(details.id)
+            const suggestedName = details.filename
+                || responseFileName
+                || getFileFromUrl(downloadUrl)
             const item: DownloadRequestItem = {
                 link: downloadUrl,
                 description: null,
                 downloadPage: downloadPage,
                 headers: requestHeaders,
-                suggestedName: null,
+                suggestedName,
                 type: "http",
             };
-            await this.requestAddDownload(item)
+            if (shouldDeferGoogleDriveDownloadToBrowser(downloadPage, downloadUrl)) {
+                await this.requestGoogleDriveCapturedDownload(
+                    {
+                        item,
+                        fileName: suggestedName,
+                        contentLength: responseContentLength,
+                    },
+                    interceptedRequest?.finalRequest.tabId,
+                )
+            } else {
+                await this.requestAddDownload(item)
+            }
         })
     }
 

--- a/src/linkgrabber/GoogleDriveDownloadBatching.ts
+++ b/src/linkgrabber/GoogleDriveDownloadBatching.ts
@@ -1,0 +1,96 @@
+import {
+    DownloadRequestBundleSource,
+    DownloadRequestItem,
+} from "~/interfaces/DownloadRequestItem";
+
+export const GOOGLE_DRIVE_BATCH_DEBOUNCE_MS = 750
+export const GOOGLE_DRIVE_BATCH_MAX_WAIT_MS = 2_500
+
+export interface GoogleDriveCapturedDownload {
+    item: DownloadRequestItem
+    fileName: string | null
+    contentLength: number | null
+}
+
+export function getGoogleDriveBatchKey(
+    tabId: number | null | undefined,
+    downloadPage: string | null,
+): string {
+    if (tabId !== null && tabId !== undefined && tabId >= 0) {
+        return `tab:${tabId}`
+    }
+    if (!downloadPage) {
+        return "page:unknown"
+    }
+    try {
+        return `page:${new URL(downloadPage).origin}`
+    } catch (_) {
+        return "page:unknown"
+    }
+}
+
+function normalizeFileName(value: string | null): string | null {
+    const name = value?.split(/[\\/]/).pop()?.trim()
+    return name || null
+}
+
+export function getGoogleDriveBundleName(fileNames: Array<string | null>): string {
+    const normalized = fileNames.map(normalizeFileName).filter((name): name is string => name !== null)
+    const numberedZip = normalized.find(name => /-\d{3}\.zip$/i.test(name))
+    if (numberedZip) {
+        return numberedZip.replace(/-\d{3}(\.zip)$/i, "$1")
+    }
+    const firstZip = normalized.find(name => name.toLowerCase().endsWith(".zip"))
+    if (firstZip) {
+        return firstZip
+    }
+    return "google-drive-download.zip"
+}
+
+export function createGoogleDriveDownloadRequest(
+    captures: GoogleDriveCapturedDownload[],
+): DownloadRequestItem[] {
+    if (captures.length <= 1) {
+        const capture = captures[0]
+        if (!capture) {
+            return []
+        }
+        return [{
+            ...capture.item,
+            suggestedName: normalizeFileName(capture.fileName) ?? capture.item.suggestedName,
+        }]
+    }
+
+    if (captures.some(capture => capture.contentLength === null || capture.contentLength < 0)) {
+        return captures.map(capture => ({
+            ...capture.item,
+            suggestedName: normalizeFileName(capture.fileName) ?? capture.item.suggestedName,
+        }))
+    }
+
+    const sorted = [...captures].sort((left, right) => {
+        return (normalizeFileName(left.fileName) ?? left.item.link).localeCompare(
+            normalizeFileName(right.fileName) ?? right.item.link,
+            undefined,
+            {numeric: true, sensitivity: "base"},
+        )
+    })
+    const sources: DownloadRequestBundleSource[] = sorted.map(capture => ({
+        link: capture.item.link,
+        headers: capture.item.headers,
+        suggestedName: normalizeFileName(capture.fileName)
+            ?? capture.item.suggestedName
+            ?? "download",
+        contentLength: capture.contentLength ?? -1,
+    }))
+    const first = sorted[0].item
+    return [{
+        link: first.link,
+        downloadPage: first.downloadPage,
+        headers: null,
+        description: null,
+        suggestedName: getGoogleDriveBundleName(sorted.map(it => it.fileName)),
+        type: "http-bundle",
+        sources,
+    }]
+}

--- a/src/linkgrabber/GoogleDriveDownloadInterception.ts
+++ b/src/linkgrabber/GoogleDriveDownloadInterception.ts
@@ -1,21 +1,21 @@
 const GOOGLE_DRIVE_PAGE_HOST = "drive.google.com"
 const GOOGLE_DRIVE_DOWNLOAD_HOST = "drive.usercontent.google.com"
 
-function hasHost(url: string | null, expectedHost: string): boolean {
+function hasHost(url: string | null, expectedHost: string, includeSubdomains = false): boolean {
     if (!url) {
         return false
     }
     try {
-        return new URL(url).hostname === expectedHost
+        const host = new URL(url).hostname
+        return host === expectedHost || (includeSubdomains && host.endsWith(`.${expectedHost}`))
     } catch (_) {
         return false
     }
 }
 
 /**
- * Google Drive may issue several downloadable responses while preparing an
- * archive. Let the browser finish that workflow and capture its final download
- * through browser.downloads.onCreated instead.
+ * Google Drive may issue several browser downloads for one generated archive.
+ * Let those responses reach browser.downloads.onCreated so they can be grouped.
  */
 export function shouldDeferGoogleDriveDownloadToBrowser(
     downloadPage: string | null,
@@ -23,5 +23,5 @@ export function shouldDeferGoogleDriveDownloadToBrowser(
 ): boolean {
     return hasHost(downloadPage, GOOGLE_DRIVE_PAGE_HOST)
         || hasHost(downloadUrl, GOOGLE_DRIVE_PAGE_HOST)
-        || hasHost(downloadUrl, GOOGLE_DRIVE_DOWNLOAD_HOST)
+        || hasHost(downloadUrl, GOOGLE_DRIVE_DOWNLOAD_HOST, true)
 }

--- a/src/linkgrabber/GoogleDriveDownloadInterception.ts
+++ b/src/linkgrabber/GoogleDriveDownloadInterception.ts
@@ -1,0 +1,27 @@
+const GOOGLE_DRIVE_PAGE_HOST = "drive.google.com"
+const GOOGLE_DRIVE_DOWNLOAD_HOST = "drive.usercontent.google.com"
+
+function hasHost(url: string | null, expectedHost: string): boolean {
+    if (!url) {
+        return false
+    }
+    try {
+        return new URL(url).hostname === expectedHost
+    } catch (_) {
+        return false
+    }
+}
+
+/**
+ * Google Drive may issue several downloadable responses while preparing an
+ * archive. Let the browser finish that workflow and capture its final download
+ * through browser.downloads.onCreated instead.
+ */
+export function shouldDeferGoogleDriveDownloadToBrowser(
+    downloadPage: string | null,
+    downloadUrl: string,
+): boolean {
+    return hasHost(downloadPage, GOOGLE_DRIVE_PAGE_HOST)
+        || hasHost(downloadUrl, GOOGLE_DRIVE_PAGE_HOST)
+        || hasHost(downloadUrl, GOOGLE_DRIVE_DOWNLOAD_HOST)
+}

--- a/src/utils/AsyncBatcher.ts
+++ b/src/utils/AsyncBatcher.ts
@@ -1,0 +1,76 @@
+export interface AsyncBatcherOptions {
+    debounceMs: number
+    maxWaitMs: number
+}
+
+interface PendingBatch<T, R> {
+    items: T[]
+    result: Promise<R>
+    resolve: (result: R) => void
+    reject: (reason: unknown) => void
+    startedAt: number
+    timer: ReturnType<typeof setTimeout> | null
+}
+
+/** Collects items with the same key after a short quiet period. */
+export class AsyncBatcher<T, R> {
+    private readonly batches = new Map<string, PendingBatch<T, R>>()
+
+    constructor(
+        private readonly flush: (items: T[]) => Promise<R>,
+        private readonly options: AsyncBatcherOptions,
+    ) {
+    }
+
+    enqueue(key: string, item: T): Promise<R> {
+        let batch = this.batches.get(key)
+        if (!batch) {
+            let resolve!: (result: R) => void
+            let reject!: (reason: unknown) => void
+            const result = new Promise<R>((resolvePromise, rejectPromise) => {
+                resolve = resolvePromise
+                reject = rejectPromise
+            })
+            batch = {
+                items: [],
+                result,
+                resolve,
+                reject,
+                startedAt: Date.now(),
+                timer: null,
+            }
+            this.batches.set(key, batch)
+        }
+
+        batch.items.push(item)
+        this.scheduleFlush(key, batch)
+        return batch.result
+    }
+
+    private scheduleFlush(key: string, batch: PendingBatch<T, R>) {
+        if (batch.timer !== null) {
+            clearTimeout(batch.timer)
+        }
+        const elapsed = Date.now() - batch.startedAt
+        const remainingMaxWait = Math.max(0, this.options.maxWaitMs - elapsed)
+        batch.timer = setTimeout(() => {
+            void this.flushBatch(key, batch)
+        }, Math.min(this.options.debounceMs, remainingMaxWait))
+    }
+
+    private async flushBatch(key: string, batch: PendingBatch<T, R>) {
+        if (this.batches.get(key) !== batch) {
+            return
+        }
+        this.batches.delete(key)
+        if (batch.timer !== null) {
+            clearTimeout(batch.timer)
+        }
+
+        try {
+            batch.resolve(await this.flush([...batch.items]))
+        } catch (error) {
+            batch.reject(error)
+        }
+    }
+}


### PR DESCRIPTION
### Summary

- Let Google Drive archive responses reach rowser.downloads.onCreated instead of intercepting each response early.
- Batch responses from the same tab after a short quiet period and send one http-bundle request to the app.
- Preserve each source URL, request headers, filename, and content length, and derive one archive filename from numbered ZIP parts.
- Keep the existing single-download behavior and fall back to regular requests when a safe composite request cannot be formed.

### Testing

- 
pm run build — Chrome and Firefox production builds passed.
- Real Google Drive archive: 13 responses became one app dialog and one final ZIP with the aggregate size.

Related discussion: https://github.com/amir1376/ab-download-manager/issues/1359
Required app support: https://github.com/amir1376/ab-download-manager/pull/1360