### PR TITLE
support combinations for the bypass shortcut

### DIFF
--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -159,7 +159,10 @@
     "message": "Bypass Shortcut"
   },
   "config_press_a_key": {
-    "message": "Press a key..."
+    "message": "Press a key or a combination..."
+  },
+  "config_bypass_shortcut_control_mac_warning": {
+    "message": "On macOS, Control + click is the secondary click, so the click never reaches the page. Pick another key."
   },
   "config_bypass_shortcut_description": {
     "message": "When auto-capture of download links is enabled, holding down the shortcut key and clicking on the download link uses the internal browser download method."

--- a/src/background/BackgroundSharedState.ts
+++ b/src/background/BackgroundSharedState.ts
@@ -1,14 +1,15 @@
 import {getLatestConfig} from "~/configs/Config";
+import {shortcutMatches} from "~/utils/Shortcut";
 
 
-let holdingKey = ""
+let holdingShortcut = ""
 
-export function setHoldingKey(key: string) {
-    holdingKey = key
+export function setHoldingKey(shortcut: string) {
+    holdingShortcut = shortcut
 }
 
 export function isBypassShortcutPressed() {
-    // When auto-capture of download links is enabled, holding down the shortcut key
+    // When auto-capture of download links is enabled, holding down the shortcut
     // and clicking on the download link uses the internal browser download method.
-    return holdingKey === getLatestConfig().bypassShortcut
+    return shortcutMatches(holdingShortcut, getLatestConfig().bypassShortcut)
 }

--- a/src/contentscripts/ContentScript.ts
+++ b/src/contentscripts/ContentScript.ts
@@ -73,7 +73,7 @@ export default defineExtensionEntry()
                 showPopupDelayed.cancel()
             })
 
-            document.addEventListener("mouseup", () => {
+            document.addEventListener("mouseup", (mouseEvent) => {
                 showPopupDelayed(() => {
                     const mousePositionInPage = mousePosition.getMousePositionInPage();
                     if (!shouldCreatePopup() || mousePositionInPage === null) {
@@ -97,7 +97,7 @@ export default defineExtensionEntry()
                     try {
                         await sendMessage(
                             DefinedCommands.SET_HOLDING_KEY,
-                            HoldingKeyTracker.getHoldingKey(),
+                            HoldingKeyTracker.getHoldingShortcut(mouseEvent),
                             "background"
                         )
                     } catch (e) {

--- a/src/optionsui/OptionUi.tsx
+++ b/src/optionsui/OptionUi.tsx
@@ -20,6 +20,8 @@ import {Nullable, WithSetters} from "~/utils/Types";
 import {defineExtensionEntry} from "~/utils/DefineExtensionEntry";
 import {createRoot} from "react-dom/client";
 import OptionUiEntryType from "~/utils/EntryPointTypes/OptionUi/OptionUiEntryType";
+import {isModifierKey, normalizeShortcut, parseShortcut} from "~/utils/Shortcut";
+import {isMac} from "~/utils/platform/Platform";
 
 class ToolsViewModelEvent {
 }
@@ -554,31 +556,75 @@ function ShortcutCapture(
     }
 ) {
     const [isCapturing, setIsCapturing] = useState(false)
+    const [heldModifiers, setHeldModifiers] = useState<string[]>([])
     const canBeReset = useMemo(() => {
         return props.defaultValue !== undefined && props.defaultValue !== props.value
     }, [props.defaultValue, props.value])
+    // ctrl+click is the secondary click on mac, the click never reaches the page
+    const isUnusableOnMac = useMemo(() => {
+        return isMac() && parseShortcut(props.value).includes("Control")
+    }, [props.value])
+
+    function stopCapturing(target: EventTarget | null) {
+        setHeldModifiers([])
+        setIsCapturing(false)
+        ;(target as HTMLElement | null)?.blur()
+    }
+
+    function modifiersOf(e: React.KeyboardEvent): string[] {
+        const modifiers: string[] = []
+        if (e.ctrlKey) modifiers.push("Control")
+        if (e.altKey) modifiers.push("Alt")
+        if (e.shiftKey) modifiers.push("Shift")
+        if (e.metaKey) modifiers.push("Meta")
+        return modifiers
+    }
 
     return <div className="flex flex-col space-y-2">
         <div className="flex items-center space-x-2">
             <input
                 type="text"
                 readOnly
-                value={isCapturing ? "" : props.value}
+                value={isCapturing ? normalizeShortcut(heldModifiers) : props.value}
                 placeholder={
                     isCapturing
                         ? browser.i18n.getMessage("config_press_a_key")
                         : props.value
                 }
                 onFocus={() => setIsCapturing(true)}
-                onBlur={() => setIsCapturing(false)}
+                onBlur={() => {
+                    setHeldModifiers([])
+                    setIsCapturing(false)
+                }}
                 onKeyDown={(e) => {
+                    // tab is left alone, it is the only way out of the field with the keyboard
+                    if (e.key === "Tab") {
+                        stopCapturing(null)
+                        return
+                    }
                     e.preventDefault()
                     e.stopPropagation()
-                    if (e.key) {
-                        props.onChange(e.key)
-                        setIsCapturing(false)
-                        ;(e.target as HTMLElement).blur()
+                    // escape cancels and keeps the previous shortcut
+                    if (e.key === "Escape") {
+                        stopCapturing(e.target)
+                        return
                     }
+                    const modifiers = modifiersOf(e)
+                    if (isModifierKey(e.key)) {
+                        setHeldModifiers(modifiers)
+                        return
+                    }
+                    props.onChange(normalizeShortcut([...modifiers, e.key]))
+                    stopCapturing(e.target)
+                }}
+                onKeyUp={(e) => {
+                    // a shortcut made only of modifiers is taken when the first one is released
+                    if (!isCapturing || heldModifiers.length === 0) {
+                        return
+                    }
+                    e.preventDefault()
+                    props.onChange(normalizeShortcut(heldModifiers))
+                    stopCapturing(e.target)
                 }}
                 className={classNames(
                     "input input-sm flex-1 cursor-pointer select-none",
@@ -587,6 +633,13 @@ function ShortcutCapture(
                 )}
             />
         </div>
+        {
+            isUnusableOnMac && (
+                <div className="text-warning">
+                    {browser.i18n.getMessage("config_bypass_shortcut_control_mac_warning")}
+                </div>
+            )
+        }
         {
             canBeReset && (
                 <div

--- a/src/utils/HoldingKeyTracker.ts
+++ b/src/utils/HoldingKeyTracker.ts
@@ -1,20 +1,40 @@
-let holdingKey = ""
+import {Nullable} from "~/utils/Types";
+import {isModifierKey, normalizeKey, normalizeShortcut} from "~/utils/Shortcut";
+
+type ModifierState = Pick<MouseEvent, "ctrlKey" | "altKey" | "shiftKey" | "metaKey">
+
+const heldKeys = new Set<string>()
 
 export function clear() {
-    holdingKey = ""
+    heldKeys.clear()
 }
 
-export function getHoldingKey() {
-    return holdingKey
+/**
+ * modifiers are read from the event being handled rather than from the keydown/keyup pair,
+ * the os does not reliably deliver a keyup for them (on mac holding command swallows it)
+ */
+export function getHoldingShortcut(modifierState: Nullable<ModifierState> = null) {
+    const keys: string[] = []
+    if (modifierState) {
+        if (modifierState.ctrlKey) keys.push("Control")
+        if (modifierState.altKey) keys.push("Alt")
+        if (modifierState.shiftKey) keys.push("Shift")
+        if (modifierState.metaKey) keys.push("Meta")
+    }
+    heldKeys.forEach((key) => keys.push(key))
+    return normalizeShortcut(keys)
 }
 
 export function boot() {
     document.addEventListener("keydown", (e) => {
-        holdingKey = e.key
+        if (isModifierKey(e.key)) {
+            return
+        }
+        heldKeys.add(normalizeKey(e.key))
     })
 
     document.addEventListener("keyup", (e) => {
-        clear()
+        heldKeys.delete(normalizeKey(e.key))
     })
 
     window.addEventListener('blur', function () {

--- a/src/utils/Shortcut.ts
+++ b/src/utils/Shortcut.ts
@@ -1,0 +1,62 @@
+import {isMac} from "~/utils/platform/Platform";
+
+const MODIFIERS = ["Control", "Alt", "Shift", "Meta"] as const
+
+export function isModifierKey(key: string) {
+    return (MODIFIERS as readonly string[]).includes(key)
+}
+
+/**
+ * a single character arrives in the case the keyboard produced it ("a" without shift, "A" with it)
+ * a shortcut should not depend on that
+ */
+export function normalizeKey(key: string) {
+    if (key === " ") {
+        return "Space"
+    }
+    if (key.length === 1) {
+        return key.toUpperCase()
+    }
+    return key
+}
+
+/**
+ * modifiers first and always in the same order, so "Shift+Alt" and "Alt+Shift" are one shortcut
+ */
+export function normalizeShortcut(keys: string[]): string {
+    const normalized = keys.map(normalizeKey)
+    const modifiers = MODIFIERS.filter((modifier) => normalized.includes(modifier))
+    const rest = normalized
+        .filter((key) => !isModifierKey(key))
+        .filter((key, index, all) => all.indexOf(key) === index)
+        .sort()
+    return [...modifiers, ...rest].join("+")
+}
+
+export function parseShortcut(shortcut: string): string[] {
+    return shortcut.split("+").filter((key) => key.length > 0)
+}
+
+/**
+ * the mac key labelled `delete` reports "Backspace", "Delete" is only produced by fn+delete.
+ * users who picked "Delete" from the old two option list kept a shortcut they cannot press,
+ * so on mac a configured "Delete" accepts "Backspace" as well
+ */
+function acceptedVariantsOf(shortcut: string): string[] {
+    const keys = parseShortcut(shortcut)
+    if (!isMac() || !keys.includes("Delete")) {
+        return [shortcut]
+    }
+    const withBackspace = normalizeShortcut(
+        keys.map((key) => key === "Delete" ? "Backspace" : key)
+    )
+    return [shortcut, withBackspace]
+}
+
+export function shortcutMatches(pressed: string, configured: string): boolean {
+    if (pressed.length === 0 || configured.length === 0) {
+        return false
+    }
+    return acceptedVariantsOf(normalizeShortcut(parseShortcut(configured)))
+        .includes(normalizeShortcut(parseShortcut(pressed)))
+}


### PR DESCRIPTION
Follow-up to #69. Closes the two parts of #68 that are still open plus two problems the new settings field introduced

## What changes

1. **Combinations work.** `Alt+Shift`, `Alt+K`, any mix. `HoldingKeyTracker` keeps a set of held keys instead of the last one. Order is normalized, so `Shift+Alt` and `Alt+Shift` are the same shortcut. Matching is exact: `Alt` configured does not fire when `Alt+Shift` is held.
2. **Modifiers are read from the click event**, not from the keydown/keyup pair. macOS does not deliver keyup for a key held while Command is down, which leaves a modifier stuck. The event always has the truth.
3. **A stored `Delete` accepts `Backspace` on macOS.** Anyone who picked `Delete` from the old two-option list still has it in storage, and `#69` only changed the default — their shortcut is still unpressable. This is the compatibility shim proposed in #68, not a storage migration.
4. **Escape and Tab no longer become the shortcut.** Escape cancels and keeps the previous value; Tab moves focus on. Before this, focusing the field meant you had to store *something*.
5. **`Control` is flagged on macOS.** ctrl+click is the secondary click there, so the click never reaches the page and the shortcut can never fire. The option stays, the warning explains why it will not work.

## Test results

CDP on Chrome 151 / macOS 26

| Configured | Held | Result |
|---|---|---|
| `Backspace` | ⌫ | bypassed |
| `Backspace` | nothing | captured |
| `Alt+Shift` | Alt+Shift | bypassed |
| `Alt+Shift` | Shift+Alt | bypassed |
| `Alt+Shift` | Alt only | captured |
| `Alt+K` | Alt+K | bypassed |
| `Alt` | Alt+Shift | captured |
| `Delete` | ⌫ | bypassed |
| `Delete` | ⌦ | bypassed |
| `Delete` | nothing | captured |
