### PR TITLE
Dedupe add requests between the two download capture listeners

### DIFF
--- a/src/linkgrabber/DownloadLinkInterceptor.ts
+++ b/src/linkgrabber/DownloadLinkInterceptor.ts
@@ -214,8 +214,43 @@ export abstract class DownloadLinkInterceptor {
     }
 
 
+    // One download must produce exactly one add request.
+    //
+    // A download can be observed more than once: by browser.webRequest.onHeadersReceived
+    // and by browser.downloads.onCreated (and in MV3 the response cannot be blocked -
+    // canBlockResponse() is false - so the browser always creates the download item as
+    // well). The handledOnWebRequest flag only covers one direction: it is written by the
+    // onHeadersReceived listener, read only by downloads.onCreated, and it lives on a
+    // single request record - so a second record for the same file (a second
+    // frame/navigation, a page retry after the browser download is cancelled, a resumed
+    // request) is handed over again.
+    //
+    // Remember the links that were handed over, so a repeat is a no-op. A failed
+    // hand-over releases the link again, so the sibling listener (or the browser's own
+    // download, when allowPassDownloadIfAppNotRespond is on) can still take over.
     protected async requestAddDownload(item: DownloadRequestItem) {
+        const link = item.link
+        const now = Date.now()
+        const dedupeWindowMs = 4_000
+        const recentlyAddRequested = (this.recentlyAddRequestedLinks ??= new Map<string, number>())
+        for (const [requestedLink, requestedAt] of recentlyAddRequested) {
+            if (now - requestedAt > dedupeWindowMs) {
+                recentlyAddRequested.delete(requestedLink)
+            }
+        }
+        if (link && recentlyAddRequested.has(link)) {
+            // the sibling listener already handed this download over to the app
+            return true
+        }
+        if (link) {
+            recentlyAddRequested.set(link, now)
+        }
         const result = await addDownload([item])
+        if (!result && link) {
+            // the app could not take it, so let the sibling listener (or the
+            // browser itself, if that is allowed) have another go
+            recentlyAddRequested.delete(link)
+        }
         if (getLatestConfig().allowPassDownloadIfAppNotRespond) {
             return result
         }


### PR DESCRIPTION
**Correction up front:** the first version of this description claimed `downloads.onCreated` usually wins the race. That is not something I measured, and I have withdrawn it — see "What is measured" below. The change itself is unchanged; only my explanation of the trigger was wrong.

### Symptom

One download produces two add-download windows in the app.

### What is measured

- `POST http://127.0.0.1:15151/add` with the extension's own payload returns `200 OK` in ~23 ms and opens **exactly one** add-download window. So two windows means `requestAddDownload` was called twice with the same link; it is not a transport retry and not the app.
- The same capture shows the existing guard working as intended, in the order it was designed for:

  ```
  hook:hdr             <file url>    # onHeadersReceived: decision made, about to send
  send                 <file url>
  hook:onCreated:entry <file url>
  onCreated:latch-set  <file url>    # handledOnWebRequest seen -> cancelDownload + return
  ```

  So `DownloadLinkInterceptor.ts#L439` handles the headers-first order correctly.
- On the affected machine the duplicate stopped when `requestAddDownload` became idempotent per link, with the same bundle otherwise, and did not stop for an unrelated earlier change of mine.

### What I think is not covered

`handledOnWebRequest` is written by the `onHeadersReceived` listener (L374) and read in exactly one place, `downloads.onCreated` (L439). The `onHeadersReceived` path sends unconditionally (L377) — it never consults the flag. Because the flag also lives on a single request record, the guard can only suppress a send *from `downloads.onCreated`, for that one record*. A second record for the same file — a second frame/navigation, a page retry after we cancel the browser download, a resumed/range re-request — passes `shouldHandleRequestForDirectDownload` on its own record and is handed over again.

I have not yet observed which of those produces the second record, so I am not claiming one.

### Change

`requestAddDownload` remembers the links it handed over, for a short window, so a repeat is a no-op; a failed hand-over releases the link again so the sibling listener (or the browser's own download, when `allowPassDownloadIfAppNotRespond` is on) can still take over.

- one method in `src/linkgrabber/DownloadLinkInterceptor.ts`, no other file touched;
- the context menu and popup paths call `addDownload` directly, so user-initiated adds are unaffected;
- trade-off: two downloads of the *same* URL inside the window are treated as one. The duplicate arrives within milliseconds in the traces I have, so the window is deliberately short (4 s).

### Verification

- `npx tsc --noEmit`: same 3 pre-existing `src/` errors before and after.
- `cross-env EXTENSION_TARGET=chrome vite build`: clean.
- Driven the built artifacts: the minified `requestAddDownload` from a `master` build with a counting stand-in for the app call hands one download over twice; the same build of this branch once. Edge cases: different links are never merged, a deliberate re-download after the window goes through, a failed hand-over is retried, `allowPassDownloadIfAppNotRespond` still reports the failure.
- End-to-end in a Chromium-based browser: one window instead of two.

### If you'd rather not have a Map here

Say the word and I'll reshape it (dedupe inside `addDownload()` keyed on the serialized item, mark the download as taken inside `downloads.onCreated`, or give `AddDownloadRequest` an id and dedupe in the app). I can also finish the diagnosis first: I have an instrumented build that logs both hooks and the dedupe decision with URLs, plus a switch that leaves your logic untouched (`--no-dedupe`), so the duplicate's event order can be captured on a machine where it still reproduces. Happy to hold this PR until that trace says which fix belongs where.